### PR TITLE
상세화면 공유 모달/사진 투어 모달 추가

### DIFF
--- a/src/components/home/Topbar/Search/modals/GuestsModal.tsx
+++ b/src/components/home/Topbar/Search/modals/GuestsModal.tsx
@@ -51,7 +51,7 @@ const GuestsModal = ({ onClose }: GuestsModalProps) => {
         </div>
       </div>
 
-      <div className="flex items-center mt-6 pt-4 border-t">
+      <div className="flex items-center mt-6 pt-4 border-t gap-8">
         <button onClick={onClose} className="text-base underline font-medium">
           취소
         </button>

--- a/src/components/roomdetail/Info.tsx
+++ b/src/components/roomdetail/Info.tsx
@@ -39,11 +39,11 @@ const Info = ({ data }: InfoProps) => {
       </div>
       <div className="flex justify-between border border-gray-300 rounded-md p-6 w-full my-8">
         <div className="flex justify-center align-center gap-1 flex-1 border-r border-r-gray-300">
-          <img src={crownleft} />
-          <div className="text-center">
+          <img src={crownleft} className="basis-1/10" />
+          <div className="text-sm text-center">
             게스트<br></br>선호
           </div>
-          <img src={crownright} />
+          <img src={crownright} className="basis-1/10" />
         </div>
         <div className="flex flex-col flex-1 items-center border-r border-r-gray-300">
           <div>{data.avgrating}</div>
@@ -60,7 +60,7 @@ const Info = ({ data }: InfoProps) => {
           <div className="text-xs underline">후기</div>
         </div>
       </div>
-      <div className="grid grid-cols-2 grid-rows-3 w-full h-[150px] pb-[30px] border-b border-b-gray-300">
+      <div className="grid grid-cols-2 grid-rows-3 w-full h-fit pb-[30px] border-b border-b-gray-300 gap-4">
         <div className="col-span-1 row-span-1 flex gap-2 items-center px-4">
           {matchingItem !== undefined ? (
             <>
@@ -122,7 +122,7 @@ const Info = ({ data }: InfoProps) => {
           </div>
         </div>
       </div>
-      <div className="flex items-center justify-start w-full h-[100px] py-4 px-8 border-b border-b-gray-300">
+      <div className="flex items-center justify-start w-full h-fit py-4 px-8 border-b border-b-gray-300">
         <div className="mr-5 bg-gray-300 p-4 rounded-full">
           <PhotoSizeSelectActualIcon className="text-white" />
         </div>
@@ -133,7 +133,7 @@ const Info = ({ data }: InfoProps) => {
           </div>
         </div>
       </div>
-      <div className="text-wrap px-4 py-8">{data.info}</div>
+      <div className="w-full h-fit text-wrap px-4 py-8">{data.info}</div>
     </div>
   );
 };

--- a/src/components/roomdetail/PhotoModal.tsx
+++ b/src/components/roomdetail/PhotoModal.tsx
@@ -1,0 +1,56 @@
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import PhotoSizeSelectActualIcon from '@mui/icons-material/PhotoSizeSelectActual';
+
+import { Shareheart } from '@/components/roomdetail/Shareheart';
+
+const PhotoModal = ({ onClose }: { onClose: () => void }) => {
+  const photos = [
+    { title: '거실', icon: <PhotoSizeSelectActualIcon /> },
+    { title: '침실', icon: <PhotoSizeSelectActualIcon /> },
+    { title: '욕실', icon: <PhotoSizeSelectActualIcon /> },
+    { title: '외부', icon: <PhotoSizeSelectActualIcon /> },
+    { title: '추가 사진', icon: <PhotoSizeSelectActualIcon /> },
+  ];
+
+  return (
+    <div className="fixed inset-0 bg-white rounded-lg shadow-lg w-full h-full overflow-y-auto p-6">
+      {/* 헤더 */}
+      <div className="flex justify-between items-center mb-4 cursor-pointer">
+        <div className="flex-1">
+          <ChevronLeftIcon className="w-8 h-8" onClick={onClose} />
+        </div>
+        <h2 className="flex-1 text-2xl font-semibold text-center">사진 투어</h2>
+        <div className="flex-1 flex justify-end">
+          <Shareheart />
+        </div>
+      </div>
+
+      {/* 사진 목록 */}
+      <div className="grid grid-cols-5 gap-4 mb-6">
+        {photos.map((photo, index) => (
+          <div
+            key={index}
+            className="flex flex-col items-center justify-center space-y-2 cursor-pointer"
+          >
+            <div className="w-full h-24 bg-gray-300 text-white flex items-center justify-center rounded-sm shadow-md">
+              {photo.icon}
+            </div>
+            <span className="text-sm text-gray-700">{photo.title}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* 선택한 사진 보기 */}
+      <div className="flex flex-col items-center">
+        <div className="w-full h-[300px] bg-gray-300 rounded-sm flex items-center justify-center shadow-md">
+          <PhotoSizeSelectActualIcon
+            style={{ fontSize: '50px', color: 'white' }}
+          />
+        </div>
+        <h3 className="mt-4 text-lg font-normal">거실</h3>
+      </div>
+    </div>
+  );
+};
+
+export default PhotoModal;

--- a/src/components/roomdetail/Reservation.tsx
+++ b/src/components/roomdetail/Reservation.tsx
@@ -1,78 +1,163 @@
 import ErrorIcon from '@mui/icons-material/Error';
 import FlagIcon from '@mui/icons-material/Flag';
+import axios from 'axios';
 
+import BaseModal from '@/components/common/Modal/BaseModal';
+import { useSearch } from '@/components/home/context/SearchContext';
+import CalendarModal from '@/components/home/Topbar/Search/modals/CalendarModal';
+import GuestsModal from '@/components/home/Topbar/Search/modals/GuestsModal';
 import clock from '@/components/roomdetail/clock.svg';
+import type { roomType } from '@/types/roomType';
 
-const Reservation = () => {
+interface InfoProps {
+  data: roomType;
+}
+
+const Reservation = ({ data }: InfoProps) => {
+  const { checkIn, checkOut, guests, currentModal, openModal, closeModal } =
+    useSearch();
+
+  const handleReservation = async () => {
+    if (data.id === 0 || checkIn == null || checkOut == null || guests <= 0) {
+      alert('모든 정보를 입력해주세요.');
+      return;
+    }
+    const token = localStorage.getItem('token') as string;
+    const reservationData = {
+      roomId: data.id,
+      startDate: checkIn.toISOString().split('T')[0],
+      endDate: checkOut.toISOString().split('T')[0],
+      numberOfGuests: guests,
+    };
+    console.debug('전송할 데이터:', reservationData);
+    try {
+      const response = await axios.post(
+        '/api/v1/reservations',
+        reservationData,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`, // 필요한 경우 토큰을 추가
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+      console.debug('응답 데이터:', response.data);
+
+      if (response.status === 200) {
+        alert('예약이 성공적으로 완료되었습니다!');
+      }
+    } catch (error) {
+      console.error('예약 요청 실패:', error);
+      alert('예약 중 문제가 발생했습니다. 다시 시도해주세요.');
+    }
+  };
+
   return (
-    <div className="flex flex-col items-center w-full h-fit mt-8">
-      {/* Date Selection Section */}
-      <div className="flex flex-col items-center rounded-lg p-4 w-full shadow-xl border">
-        <div className="flex justify-between w-full">
-          <div className="w-full">
-            <label className="block text-sm font-medium text-gray-700">
-              체크인
-            </label>
-            <input
-              type="text"
-              value="2025. 1. 7."
-              readOnly
-              className="mt-1 block w-full border border-red-700 rounded-tl-md py-2 px-3 text-gray-700 bg-white cursor-pointer"
+    <>
+      <div className="flex flex-col items-center w-full h-fit mt-8">
+        {/* Date Selection Section */}
+        <div className="flex flex-col items-center rounded-lg p-4 w-full shadow-xl border">
+          <div className="flex justify-between gap-4 w-full">
+            <div className="w-full">
+              <button
+                onClick={() => {
+                  openModal('calendar');
+                }}
+                className="flex flex-col items-start mt-1 w-full border border-red-700 rounded-md py-2 px-3 text-gray-700 bg-white cursor-pointer"
+              >
+                <span className="text-xs font-medium text-red-700">체크인</span>
+                <span className="text-sm text-black">
+                  {checkIn !== null
+                    ? checkIn.toLocaleDateString()
+                    : '날짜 추가'}
+                </span>
+              </button>
+            </div>
+            <div className="w-full">
+              <button
+                onClick={() => {
+                  openModal('calendar');
+                }}
+                className="flex flex-col items-start mt-1 w-full border border-red-700 rounded-md py-2 px-3 text-gray-700 bg-white cursor-pointer"
+              >
+                <span className="text-xs font-medium text-red-700">
+                  체크아웃
+                </span>
+                <span className="text-sm text-black">
+                  {checkOut !== null
+                    ? checkOut.toLocaleDateString()
+                    : '날짜 추가'}
+                </span>
+              </button>
+            </div>
+          </div>
+          <div className="my-4 w-full">
+            <button
+              onClick={() => {
+                openModal('guests');
+              }}
+              className="flex flex-col items-start mt-1 w-full border border-gray-300 rounded-md py-2 px-3 bg-white cursor-pointer text-gray-700"
+            >
+              <span className="block text-xs font-medium text-gray-700">
+                인원
+              </span>
+              <span className="text-sm text-gray-700">
+                {guests > 0 ? `게스트 ${guests}명` : '게스트 추가'}
+              </span>
+            </button>
+          </div>
+          <div className="flex items-center text-red-600 text-xs mb-4">
+            <ErrorIcon className="mr-2" />
+            선택하신 날짜는 이용이 불가능합니다.
+          </div>
+          <button
+            className="w-full py-2 px-4 bg-[#D70466] text-white rounded-lg hover:bg-[#E31C5F] cursor-pointer"
+            onClick={() => {
+              void handleReservation();
+            }}
+          >
+            예약하기
+          </button>
+        </div>
+
+        {/* Reservation Expiration Section */}
+        <div className="flex w-full p-4 my-8 border border-gray-200 rounded-md">
+          <div className="mr-3">
+            <img
+              src={clock}
+              className="text-[#D70466] w-[40px] h-[40px] snap-center"
             />
           </div>
-          <div className="w-full">
-            <label className="block text-sm font-medium text-gray-700">
-              체크아웃
-            </label>
-            <input
-              type="text"
-              value="2025. 1. 12."
-              readOnly
-              className="mt-1 block w-full border border-red-700 rounded-tr-md py-2 px-3 text-gray-700 bg-white cursor-pointer"
-            />
+          <div className="flex flex-col items-start">
+            <div className="text-gray-700">
+              예약이&nbsp;3시간 후에 마감됩니다
+            </div>
+            <p className="text-sm text-gray-500 text-start mt-2">
+              호스트가 해당 날짜에 대한 예약 수락을 곧 중단할 예정입니다.
+            </p>
           </div>
         </div>
-        <div className="my-4 w-full">
-          <label className="block text-sm font-medium text-gray-700">
-            인원
-          </label>
-          <select className="block mt-1 w-full border rounded-bl-md rounded-br-md py-2 px-3 bg-white cursor-pointer">
-            <option>게스트 1명</option>
-          </select>
-        </div>
-        <div className="flex items-center text-red-600 text-xs mb-4">
-          <ErrorIcon className="mr-2" />
-          선택하신 날짜는 이용이 불가능합니다.
-        </div>
-        <button className="w-full py-2 px-4 bg-[#D70466] text-white rounded-lg hover:bg-[#E31C5F] cursor-pointer">
-          날짜 변경
+        {/* Report Section */}
+        <button className="mt-2 flex items-center text-sm text-[#6A6A6A] hover:underline cursor-pointer">
+          <FlagIcon className="mr-1" />
+          숙소 신고하기
         </button>
       </div>
-
-      {/* Reservation Expiration Section */}
-      <div className="flex w-full p-4 my-8 border border-gray-200 rounded-md">
-        <div>
-          <img
-            src={clock}
-            className="mr-3 text-[#D70466] w-[40px] h-[40px] snap-center"
-          />
-        </div>
-        <div className="flex flex-col">
-          <div className="flex items-center text-gray-700">
-            예약이&nbsp;
-            <span className="font-medium">3시간 후에 마감됩니다</span>
-          </div>
-          <p className="text-sm text-gray-500 text-center mt-2">
-            호스트가 해당 날짜에 대한 예약 수락을 곧 중단할 예정입니다.
-          </p>
-        </div>
-      </div>
-      {/* Report Section */}
-      <button className="mt-2 flex items-center text-sm text-[#6A6A6A] hover:underline cursor-pointer">
-        <FlagIcon className="mr-1" />
-        숙소 신고하기
-      </button>
-    </div>
+      <BaseModal
+        isOpen={currentModal === 'calendar'}
+        onClose={closeModal}
+        title="날짜 선택"
+      >
+        <CalendarModal onClose={closeModal} />
+      </BaseModal>
+      <BaseModal
+        isOpen={currentModal === 'guests'}
+        onClose={closeModal}
+        title="인원 선택"
+      >
+        <GuestsModal onClose={closeModal} />
+      </BaseModal>
+    </>
   );
 };
 

--- a/src/components/roomdetail/ShareModal.tsx
+++ b/src/components/roomdetail/ShareModal.tsx
@@ -1,0 +1,118 @@
+import EmailIcon from '@mui/icons-material/Email';
+import FacebookIcon from '@mui/icons-material/Facebook';
+import InsertPageBreakIcon from '@mui/icons-material/InsertPageBreak';
+import LinkIcon from '@mui/icons-material/Link';
+import MessageIcon from '@mui/icons-material/Message';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import PhotoSizeSelectActualIcon from '@mui/icons-material/PhotoSizeSelectActual';
+import SendIcon from '@mui/icons-material/Send';
+import TwitterIcon from '@mui/icons-material/Twitter';
+import WhatsAppIcon from '@mui/icons-material/WhatsApp';
+import { useState } from 'react';
+
+interface ShareModalProps {
+  onClose: () => void; // 닫기 핸들러
+}
+
+const ShareModal: React.FC<ShareModalProps> = ({ onClose }) => {
+  const [copied, setCopied] = useState(false);
+  const handleCopyLink = () => {
+    const currentLink = window.location.href;
+    void navigator.clipboard.writeText(currentLink).then(() => {
+      setCopied(true);
+      setTimeout(() => {
+        setCopied(false);
+      }, 3000); // 3초 후 알림 숨기기
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 bg-gray-900 bg-opacity-50 flex justify-center items-center z-50">
+      {/* 배경 클릭 시 닫힘 */}
+      <div
+        className="absolute inset-0 bg-black bg-opacity-50"
+        onClick={onClose}
+      ></div>
+
+      {/* 모달 내용 */}
+      <div className="relative bg-white rounded-lg shadow-lg w-[50%] h-fit p-6 z-60">
+        {/* Header */}
+        <div className="flex justify-between items-center border-b pb-4">
+          <h2 className="text-lg font-semibold">숙소 공유하기</h2>
+          {/* 닫기 버튼 */}
+          <button
+            className="text-gray-500 hover:text-gray-700"
+            onClick={onClose}
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="mt-4">
+          {/* Image Section */}
+          <div className="flex items-center space-x-4">
+            <PhotoSizeSelectActualIcon className="text-gray-700 w-16 h-16" />
+            <div>
+              <h3 className="text-sm font-medium">게스트용 별채</h3>
+              <p className="text-sm text-gray-500">
+                Bonghwa-eup, Bonghwa-gun · ★4.92 · 침실 1개 · 침대 1개 · 욕실
+                1개
+              </p>
+            </div>
+          </div>
+
+          {/* Share Buttons */}
+          <div className="grid grid-cols-3 gap-4 mt-6">
+            <button
+              className="flex justify-start gap-4 items-center p-3 bg-white border border-gray-300 rounded-lg hover:bg-gray-100"
+              onClick={handleCopyLink}
+            >
+              <LinkIcon className="text-gray-700 w-6 h-6" />
+              <span className="text-sm">링크 복사</span>
+            </button>
+            {copied && (
+              <div className="absolute top-[-50px] mt-2 p-2 bg-gray-800 text-white text-xs rounded-lg shadow-lg">
+                링크가 복사되었습니다!
+              </div>
+            )}
+            <button className="flex justify-start gap-4 items-center p-3 bg-white border border-gray-300 rounded-lg hover:bg-gray-100">
+              <EmailIcon className="text-gray-700 w-6 h-6" />
+              <span className="text-sm">이메일</span>
+            </button>
+            <button className="flex justify-start gap-4 items-center p-3 bg-white border border-gray-300 rounded-lg hover:bg-gray-100">
+              <MessageIcon className="text-gray-700 w-6 h-6" />
+              <span className="text-sm">메시지</span>
+            </button>
+            <button className="flex justify-start gap-4 items-center p-3 bg-white border border-gray-300 rounded-lg hover:bg-gray-100">
+              <WhatsAppIcon className="text-gray-700 w-6 h-6" />
+              <span className="text-sm">왓츠앱</span>
+            </button>
+            <button className="flex justify-start gap-4 items-center p-3 bg-white border border-gray-300 rounded-lg hover:bg-gray-100">
+              <SendIcon className="text-gray-700 w-6 h-6" />
+              <span className="text-sm">메신저</span>
+            </button>
+            <button className="flex justify-start gap-4 items-center p-3 bg-white border border-gray-300 rounded-lg hover:bg-gray-100">
+              <FacebookIcon className="text-gray-700 w-6 h-6" />
+              <span className="text-sm">페이스북</span>
+            </button>
+            <button className="flex justify-start gap-4 items-center p-3 bg-white border border-gray-300 rounded-lg hover:bg-gray-100">
+              <TwitterIcon className="text-gray-700 w-6 h-6" />
+              <span className="text-sm">트위터</span>
+            </button>
+            <button className="flex justify-start gap-4 items-center p-3 bg-white border border-gray-300 rounded-lg hover:bg-gray-100">
+              <InsertPageBreakIcon className="text-gray-700 w-6 h-6" />
+              <span className="text-sm">삽입</span>
+            </button>
+            <button className="flex justify-start gap-4 items-center p-3 bg-white border border-gray-300 rounded-lg hover:bg-gray-100">
+              <MoreHorizIcon className="text-gray-700 w-6 h-6" />
+              <span className="text-sm">옵션 더 보기</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShareModal;

--- a/src/components/roomdetail/Shareheart.tsx
+++ b/src/components/roomdetail/Shareheart.tsx
@@ -1,0 +1,33 @@
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import IosShareIcon from '@mui/icons-material/IosShare';
+import { useState } from 'react';
+
+import ShareModal from '@/components/roomdetail/ShareModal';
+
+export const Shareheart = () => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  return (
+    <div className="flex space-x-[13px]">
+      <div
+        className="flex items-center space-x-[5px] px-2 py-1 rounded-md hover:bg-[#F7F7F7] cursor-pointer"
+        onClick={() => {
+          setIsModalOpen(true);
+        }}
+      >
+        <IosShareIcon style={{ width: 15, height: 15 }} />
+        <div className="text-sm underline">공유하기</div>
+      </div>
+      <div className="flex items-center space-x-[5px] px-2 py-1 rounded-md hover:bg-[#F7F7F7] cursor-pointer">
+        <FavoriteBorderIcon style={{ width: 15, height: 15 }} />
+        <div className="text-sm underline">저장</div>
+      </div>
+      {isModalOpen && (
+        <ShareModal
+          onClose={() => {
+            setIsModalOpen(false);
+          }}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/routes/roomDetail.tsx
+++ b/src/routes/roomDetail.tsx
@@ -1,13 +1,14 @@
-import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
-import IosShareIcon from '@mui/icons-material/IosShare';
 import PhotoSizeSelectActualIcon from '@mui/icons-material/PhotoSizeSelectActual';
 import axios from 'axios';
 import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 import gallery from '@/components/common/gallery.svg';
 import Topbar from '@/components/home/Topbar';
 import Info from '@/components/roomdetail/Info';
+import PhotoModal from '@/components/roomdetail/PhotoModal';
 import Reservation from '@/components/roomdetail/Reservation';
+import { Shareheart } from '@/components/roomdetail/Shareheart';
 import { mockRoom } from '@/mock/mockRoom';
 import type { roomType } from '@/types/roomType';
 
@@ -15,13 +16,16 @@ export const Roomdetail = () => {
   const [data, setData] = useState<roomType>(mockRoom); // 서버 응답 데이터를 저장
   const [error, setError] = useState<string | null>(null); // 에러 메시지 저장
   const [isLoading, setIsLoading] = useState<boolean>(true); // API 호출 상태 저장
-  const token =
-    'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzdHJpbmcxIiwiaWF0IjoxNzM2MjEyOTU0LCJleHAiOjE3MzYyOTkzNTR9.hOpTa8Ql-1CkswTnD2VKqrH59NEx-FokTRK3pjcJBNCxZN-FS-q44y97eiOJEXzDjJWgy0Bc3bAFXKzcQCo8iQ';
+  const [isPhotoOpen, setIsPhotoOpen] = useState<boolean>(false);
+  const { id } = useParams<{ id: string }>();
+  const token = localStorage.getItem('token') as string;
+  console.debug(token);
   useEffect(() => {
+    if (id === undefined || token.trim() === '') return;
     const fetchData = async () => {
       try {
         const response = await axios.get<roomType>(
-          'https://d1m69dle8ss110.cloudfront.net/api/v1/rooms/1',
+          `http://ec2-15-165-159-152.ap-northeast-2.compute.amazonaws.com:8080/api/v1/rooms/${id}`,
           {
             method: 'GET',
             headers: { Authorization: `Bearer ${token}` }, // 헤더에 토큰 추가
@@ -44,7 +48,7 @@ export const Roomdetail = () => {
     };
 
     void fetchData();
-  }, []); // 빈 배열: 컴포넌트가 마운트될 때 한 번만 실행
+  }, [id, token]); // 빈 배열: 컴포넌트가 마운트될 때 한 번만 실행
 
   return (
     <div className="flex flex-col justify-start items-center w-full">
@@ -52,16 +56,7 @@ export const Roomdetail = () => {
       <div className="flex flex-col w-full px-[55px]">
         <div className="flex w-full items-end justify-between py-4">
           <div className="text-2xl font-normal">{data.name}</div>
-          <div className="flex space-x-[13px]">
-            <div className="flex items-center space-x-[5px] px-2 py-1 rounded-md hover:bg-[#F7F7F7] cursor-pointer">
-              <IosShareIcon style={{ width: 15, height: 15 }} />
-              <div className="text-sm underline">공유하기</div>
-            </div>
-            <div className="flex items-center space-x-[5px] px-2 py-1 rounded-md hover:bg-[#F7F7F7] cursor-pointer">
-              <FavoriteBorderIcon style={{ width: 15, height: 15 }} />
-              <div className="text-sm underline">저장</div>
-            </div>
-          </div>
+          <Shareheart />
         </div>
         <div className="grid grid-cols-4 grid-rows-2 gap-2 w-full h-[330px]">
           <div className="col-span-2 row-span-2 flex items-center justify-center rounded-l-xl bg-gray-300  hover:bg-gray-400 cursor-pointer">
@@ -88,7 +83,12 @@ export const Roomdetail = () => {
             <PhotoSizeSelectActualIcon
               style={{ width: '50%', height: '50%', color: 'white' }}
             />
-            <button className="absolute bottom-3 right-3 px-3 py-1 gap-[5px] rounded-lg border border-black bg-white flex justify-center items-center w-fit">
+            <button
+              onClick={() => {
+                setIsPhotoOpen(true);
+              }}
+              className="absolute bottom-3 right-3 px-3 py-1 gap-[5px] rounded-lg border border-black bg-white flex justify-center items-center w-fit"
+            >
               <img src={gallery} className="w-[15px] h-[15px] snap-center" />
               <div className="text-black text-sm text-center">
                 사진 모두 보기
@@ -101,7 +101,7 @@ export const Roomdetail = () => {
             <Info data={data} />
           </div>
           <div className="flex-2">
-            <Reservation />
+            <Reservation data={data} />
           </div>
         </div>
       </div>
@@ -113,6 +113,13 @@ export const Roomdetail = () => {
         <p>서버 응답: ${data.id}</p>
       ) : (
         <p>데이터가 없습니다.</p>
+      )}
+      {isPhotoOpen && (
+        <PhotoModal
+          onClose={() => {
+            setIsPhotoOpen(false);
+          }}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## ✨ 주요 내용

1. 상세화면의 공유 모달을 구현했습니다
   - 숙소 상세 정보 일부 표시합니다
   - 링크를 복사하는 버튼이 있습니다
   
2. 상세화면의 사진 투어 모달을 구현했습니다
   - 공유/하트 컴포넌트는 'src/components/roomdetail/Shareheart.tsx' 를 재사용할 수 있습니다
   - (리팩토링 시) 위처럼 화면 내 렌더링되는 컴포넌트/api 호툴 로직은 routes 내의 페이지들에서 다른 폴더로 분리할 예정입니다

## 🚧 (중간총회까지) 앞으로 작업할 기능

1. api 연결
- 상세화면에서 mock 데이터가 아닌 api 데이터 불러오는 코드로 수정하기
- 메인화면 내의 컴포넌트 클릭 시 각각의 id 에 따른 주소 구현하기
- reservation POST 에러 해결하기

2. 사진 투어 스크롤 이상한 것 고치기