### PR TITLE
Feat/wishlist: api 연결

### DIFF
--- a/src/components/common/constants/icons/index.tsx
+++ b/src/components/common/constants/icons/index.tsx
@@ -1,4 +1,4 @@
-export { default as WifiIcon } from '@/assets/icons/amenities/wifi.svg';
-export { default as CheckinIcon } from '@/assets/icons/amenities/checkin.svg';
-export { default as LuggageIcon } from '@/assets/icons/amenities/luggage.svg';
-export { default as TvIcon } from '@/assets/icons/amenities/tv.svg';
+export { default as WifiIcon } from '@/assets/icons/roomdetail/wifi.svg';
+export { default as CheckinIcon } from '@/assets/icons/roomdetail/checkin.svg';
+export { default as LuggageIcon } from '@/assets/icons/roomdetail/luggage.svg';
+export { default as TvIcon } from '@/assets/icons/roomdetail/tv.svg';

--- a/src/components/home/context/SearchContext.tsx
+++ b/src/components/home/context/SearchContext.tsx
@@ -1,7 +1,13 @@
 import type { ReactNode } from 'react';
 import { createContext, useContext, useState } from 'react';
 
-type ModalType = 'location' | 'calendar' | 'guests' | null;
+type ModalType =
+  | 'location'
+  | 'calendar'
+  | 'guests'
+  | 'roomCalendar'
+  | 'roomGuests'
+  | null;
 
 type Location = {
   sido: string;

--- a/src/components/roomdetail/HeartModal.tsx
+++ b/src/components/roomdetail/HeartModal.tsx
@@ -44,10 +44,7 @@ const ShareModal = ({ onClose }: HeartModalProps) => {
         </div>
         <div className="grid grid-cols-2 gap-2 px-2">
           {mockHeart.map((list) => (
-            <div
-              className="flex flex-col items-start p-2"
-              key={list.name}
-            >
+            <div className="flex flex-col items-start p-2" key={list.name}>
               <PhotoSizeSelectActualIcon className="text-white bg-gray-300 w-full h-[200px] rounded-md shadow-md" />
               <p className="mt-2 text-base font-bold">{list.name}</p>
               <p className="text-gray-500 text-sm">

--- a/src/components/roomdetail/HeartModal.tsx
+++ b/src/components/roomdetail/HeartModal.tsx
@@ -29,28 +29,28 @@ const ShareModal = ({ onClose }: HeartModalProps) => {
       ></div>
 
       {/* 모달 내용 */}
-      <div className="relative bg-white rounded-lg shadow-lg w-[40%] z-60 overflow-y-auto h-[80%]">
-        <div className="grid grid-cols-3 items-center w-full border-b p-2">
+      <div className="relative bg-white rounded-lg shadow-lg w-[40%] z-60 h-[80%] overflow-y-auto">
+        <div className="sticky top-0 bg-white flex items-center w-full border-b p-2">
           <button
             onClick={onClose}
             className="text-left ml-2 text-3xl text-black"
           >
             &times;
           </button>
-          <div className="text-lg text-center font-bold">
+          <div className="text-base flex-1 text-center font-bold">
             위시리스트에 저장하기
           </div>
           <div></div>
         </div>
-        <div className="grid grid-cols-2 w-full">
+        <div className="grid grid-cols-2 gap-2 px-2">
           {mockHeart.map((list) => (
             <div
-              className="w-full flex flex-col items-start m-4"
+              className="flex flex-col items-start p-2"
               key={list.name}
             >
-              <PhotoSizeSelectActualIcon className="text-white bg-gray-300 w-full h-[200px] rounded-md" />
-              <p className="mt-2 text-lg font-bold">{list.name}</p>
-              <p className="text-gray-500">
+              <PhotoSizeSelectActualIcon className="text-white bg-gray-300 w-full h-[200px] rounded-md shadow-md" />
+              <p className="mt-2 text-base font-bold">{list.name}</p>
+              <p className="text-gray-500 text-sm">
                 저장된 항목&nbsp;{list.itemsCount}개
               </p>
             </div>
@@ -58,8 +58,8 @@ const ShareModal = ({ onClose }: HeartModalProps) => {
         </div>
 
         {/* "새로운 위시리스트 만들기" 버튼, 위치 고정 */}
-        <div className="absolute bottom-4 left-0 right-0 text-center">
-          <button className="w-full bg-blue-500 text-white p-2 rounded-md">
+        <div className="sticky bottom-0 text-center bg-white border-t w-full">
+          <button className="w-full bg-gray-900 text-white text-base p-2 rounded-md m-3">
             새로운 위시리스트 만들기
           </button>
         </div>

--- a/src/components/roomdetail/Info.tsx
+++ b/src/components/roomdetail/Info.tsx
@@ -22,7 +22,7 @@ interface InfoProps {
 
 const Info = ({ data }: InfoProps) => {
   const matchingItem = ACCOMMODATION_TYPES.find(
-    (item) => item.type === data.type,
+    (item) => item.type === data.roomType,
   );
   const issuperhost = data.isSuperhost;
   const isluggage = data.roomDetails.luggage;
@@ -53,7 +53,7 @@ const Info = ({ data }: InfoProps) => {
           <img src={crownright} className="basis-1/10" />
         </div>
         <div className="flex flex-col flex-1 items-center border-r border-r-gray-300">
-          <div>{data.rating}</div>
+          <div>{data.averageRating}</div>
           <div className="flex">
             <StarIcon className="" style={{ width: '10px', height: '10px' }} />
             <StarIcon className="" style={{ width: '10px', height: '10px' }} />
@@ -81,7 +81,7 @@ const Info = ({ data }: InfoProps) => {
               <img
                 src={matchingItem.imageUrl}
                 alt={matchingItem.label}
-                className="h-6 w-6 opacity-60 hover:opacity-100 transition-opacity"
+                className="h-6 w-6 opacity-60"
               />
               <div className="opacity-60 text-sm">{matchingItem.label}</div>
             </>
@@ -95,7 +95,7 @@ const Info = ({ data }: InfoProps) => {
         <div className="col-span-1 row-span-1 flex gap-2 items-center px-4">
           <img
             src={superhost}
-            className="h-6 w-6 opacity-60 hover:opacity-100 transition-opacity"
+            className="h-6 w-6 opacity-60"
           />
           <div className="opacity-60 text-sm">
             {issuperhost ? '슈퍼호스트' : '훌륭한 호스트'}
@@ -104,7 +104,7 @@ const Info = ({ data }: InfoProps) => {
         <div className="col-span-1 row-span-1 flex gap-2 items-center px-4">
           <img
             src={LuggageIcon}
-            className="h-6 w-6 opacity-60 hover:opacity-100 transition-opacity"
+            className="h-6 w-6 opacity-60"
           />
           <div className="opacity-60 text-sm">
             {isluggage ? '여행 가방 보관 가능' : '여행 가방 보관 풀가'}
@@ -113,7 +113,7 @@ const Info = ({ data }: InfoProps) => {
         <div className="col-span-1 row-span-1 flex gap-2 items-center px-4">
           <img
             src={CheckinIcon}
-            className="h-6 w-6 opacity-60 hover:opacity-100 transition-opacity"
+            className="h-6 w-6 opacity-60"
           />
           <div className="opacity-60 text-sm">
             {ischeckin ? '셀프체크인' : '편의성이 뛰어난 체크인 절차'}
@@ -122,14 +122,14 @@ const Info = ({ data }: InfoProps) => {
         <div className="col-span-1 row-span-1 flex gap-2 items-center px-4">
           <img
             src={TvIcon}
-            className="h-6 w-6 opacity-60 hover:opacity-100 transition-opacity"
+            className="h-6 w-6 opacity-60"
           />
           <div className="opacity-60 text-sm">{istv ? 'TV' : 'TV 없음'}</div>
         </div>
         <div className="col-span-1 row-span-1 flex gap-2 items-center px-4">
           <img
             src={WifiIcon}
-            className="h-6 w-6 opacity-60 hover:opacity-100 transition-opacity"
+            className="h-6 w-6 opacity-60"
           />
           <div className="opacity-60 text-sm">
             {iswifi ? '와이파이' : '와이파이 없음'}
@@ -150,6 +150,7 @@ const Info = ({ data }: InfoProps) => {
       <div className="w-full h-fit text-wrap px-4 py-8">{data.description}</div>
       {isReviewOpen && (
         <ReviewModal
+          data={data}
           onClose={() => {
             setIsReviewOpen(false);
           }}

--- a/src/components/roomdetail/Info.tsx
+++ b/src/components/roomdetail/Info.tsx
@@ -3,10 +3,10 @@ import StarIcon from '@mui/icons-material/Star';
 import { useState } from 'react';
 
 import { ACCOMMODATION_TYPES } from '@/components/common/constants/accommodationTypes';
-import crownleft from '@/components/roomdetail/crownleft.svg';
-import crownright from '@/components/roomdetail/crownright.svg';
+import crownleft from '@/assets/icons/roomdetail/crownleft.svg';
+import crownright from '@/assets/icons/roomdetail/crownright.svg';
 import ReviewModal from '@/components/roomdetail/ReviewModal';
-import superhost from '@/components/roomdetail/superhost.svg';
+import superhost from '@/assets/icons/superhost.svg';
 import type { roomType } from '@/types/roomType';
 
 import {

--- a/src/components/roomdetail/Info.tsx
+++ b/src/components/roomdetail/Info.tsx
@@ -2,11 +2,11 @@ import PhotoSizeSelectActualIcon from '@mui/icons-material/PhotoSizeSelectActual
 import StarIcon from '@mui/icons-material/Star';
 import { useState } from 'react';
 
-import { ACCOMMODATION_TYPES } from '@/components/common/constants/accommodationTypes';
 import crownleft from '@/assets/icons/roomdetail/crownleft.svg';
 import crownright from '@/assets/icons/roomdetail/crownright.svg';
-import ReviewModal from '@/components/roomdetail/ReviewModal';
 import superhost from '@/assets/icons/superhost.svg';
+import { ACCOMMODATION_TYPES } from '@/components/common/constants/accommodationTypes';
+import ReviewModal from '@/components/roomdetail/ReviewModal';
 import type { roomType } from '@/types/roomType';
 
 import {

--- a/src/components/roomdetail/Info.tsx
+++ b/src/components/roomdetail/Info.tsx
@@ -93,44 +93,29 @@ const Info = ({ data }: InfoProps) => {
           )}
         </div>
         <div className="col-span-1 row-span-1 flex gap-2 items-center px-4">
-          <img
-            src={superhost}
-            className="h-6 w-6 opacity-60"
-          />
+          <img src={superhost} className="h-6 w-6 opacity-60" />
           <div className="opacity-60 text-sm">
             {issuperhost ? '슈퍼호스트' : '훌륭한 호스트'}
           </div>
         </div>
         <div className="col-span-1 row-span-1 flex gap-2 items-center px-4">
-          <img
-            src={LuggageIcon}
-            className="h-6 w-6 opacity-60"
-          />
+          <img src={LuggageIcon} className="h-6 w-6 opacity-60" />
           <div className="opacity-60 text-sm">
             {isluggage ? '여행 가방 보관 가능' : '여행 가방 보관 풀가'}
           </div>
         </div>
         <div className="col-span-1 row-span-1 flex gap-2 items-center px-4">
-          <img
-            src={CheckinIcon}
-            className="h-6 w-6 opacity-60"
-          />
+          <img src={CheckinIcon} className="h-6 w-6 opacity-60" />
           <div className="opacity-60 text-sm">
             {ischeckin ? '셀프체크인' : '편의성이 뛰어난 체크인 절차'}
           </div>
         </div>
         <div className="col-span-1 row-span-1 flex gap-2 items-center px-4">
-          <img
-            src={TvIcon}
-            className="h-6 w-6 opacity-60"
-          />
+          <img src={TvIcon} className="h-6 w-6 opacity-60" />
           <div className="opacity-60 text-sm">{istv ? 'TV' : 'TV 없음'}</div>
         </div>
         <div className="col-span-1 row-span-1 flex gap-2 items-center px-4">
-          <img
-            src={WifiIcon}
-            className="h-6 w-6 opacity-60"
-          />
+          <img src={WifiIcon} className="h-6 w-6 opacity-60" />
           <div className="opacity-60 text-sm">
             {iswifi ? '와이파이' : '와이파이 없음'}
           </div>

--- a/src/components/roomdetail/Reservation.tsx
+++ b/src/components/roomdetail/Reservation.tsx
@@ -1,4 +1,3 @@
-import ErrorIcon from '@mui/icons-material/Error';
 import FlagIcon from '@mui/icons-material/Flag';
 import { useState } from 'react';
 
@@ -7,11 +6,14 @@ import { useSearch } from '@/components/home/context/SearchContext';
 import CalendarModal from '@/components/home/Topbar/Search/modals/CalendarModal';
 import GuestsModal from '@/components/home/Topbar/Search/modals/GuestsModal';
 import clock from '@/assets/icons/reservation/clock.svg';
-import type { roomReservationType } from '@/types/roomReservationType';
 import type { roomType } from '@/types/roomType';
 
 interface InfoProps {
   data: roomType;
+}
+
+type roomReservationResponseType = {
+  reservationId: number
 }
 
 const Reservation = ({ data }: InfoProps) => {
@@ -29,13 +31,13 @@ const Reservation = ({ data }: InfoProps) => {
       if (token == null) {
         throw new Error('로그인이 필요합니다.');
       }
-
-      if (data.id === 0 || checkIn == null || checkOut == null || guests <= 0) {
+      console.debug(data)
+      if (data.roomId === 0 || checkIn == null || checkOut == null || guests <= 0) {
         throw new Error('모든 필드를 입력해주세요.');
       }
 
       const sendData = {
-        roomId: data.id,
+        roomId: data.roomId,
         startDate: checkIn.toISOString().split('T')[0],
         endDate: checkOut.toISOString().split('T')[0],
         numberOfGuests: guests,
@@ -53,10 +55,10 @@ const Reservation = ({ data }: InfoProps) => {
       console.debug(sendData);
 
       if (!response.ok) {
-        throw new Error('숙소 등록에 실패했습니다.');
+        throw new Error('숙소 예약에 실패했습니다.');
       }
-      const responseData = (await response.json()) as roomReservationType;
-      alert(`숙소가 성공적으로 등록되었습니다! ID: ${responseData.roomId}`);
+      const responseData = (await response.json()) as roomReservationResponseType;
+      alert(`숙소가 성공적으로 예약되었습니다! ID: ${responseData.reservationId}`);
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : '오류가 발생했습니다.';
@@ -120,14 +122,10 @@ const Reservation = ({ data }: InfoProps) => {
               </span>
             </button>
           </div>
-          <div className="flex items-center text-red-600 text-xs mb-4">
-            <ErrorIcon className="mr-2" />
-            선택하신 날짜는 이용이 불가능합니다.
-          </div>
 
           {/* 에러 메시지 표시 */}
           {error != null && (
-            <div className="mb-4 p-4 bg-red-50 text-red-600 rounded-lg">
+            <div className="mb-4 p-2 bg-red-50 text-red-700 rounded-sm text-sm">
               {error}
             </div>
           )}

--- a/src/components/roomdetail/Reservation.tsx
+++ b/src/components/roomdetail/Reservation.tsx
@@ -6,7 +6,7 @@ import BaseModal from '@/components/common/Modal/BaseModal';
 import { useSearch } from '@/components/home/context/SearchContext';
 import CalendarModal from '@/components/home/Topbar/Search/modals/CalendarModal';
 import GuestsModal from '@/components/home/Topbar/Search/modals/GuestsModal';
-import clock from '@/components/roomdetail/clock.svg';
+import clock from '@/assets/icons/reservation/clock.svg';
 import type { roomReservationType } from '@/types/roomReservationType';
 import type { roomType } from '@/types/roomType';
 

--- a/src/components/roomdetail/Reservation.tsx
+++ b/src/components/roomdetail/Reservation.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 
 import BaseModal from '@/components/common/Modal/BaseModal';
 import { useSearch } from '@/components/home/context/SearchContext';
-import CalendarModal from '@/components/home/Topbar/Search/modals/CalendarModal';
-import GuestsModal from '@/components/home/Topbar/Search/modals/GuestsModal';
+import RoomCalendarModal from './roomCalendarModal';
+import RoomGuestsModal from '@/components/roomdetail/RoomGuestsModal';
 import clock from '@/assets/icons/reservation/clock.svg';
 import type { roomType } from '@/types/roomType';
 
@@ -13,8 +13,8 @@ interface InfoProps {
 }
 
 type roomReservationResponseType = {
-  reservationId: number
-}
+  reservationId: number;
+};
 
 const Reservation = ({ data }: InfoProps) => {
   const [isLoading, setIsLoading] = useState(false);
@@ -31,8 +31,13 @@ const Reservation = ({ data }: InfoProps) => {
       if (token == null) {
         throw new Error('로그인이 필요합니다.');
       }
-      console.debug(data)
-      if (data.roomId === 0 || checkIn == null || checkOut == null || guests <= 0) {
+      console.debug(data);
+      if (
+        data.roomId === 0 ||
+        checkIn == null ||
+        checkOut == null ||
+        guests <= 0
+      ) {
         throw new Error('모든 필드를 입력해주세요.');
       }
 
@@ -57,8 +62,11 @@ const Reservation = ({ data }: InfoProps) => {
       if (!response.ok) {
         throw new Error('숙소 예약에 실패했습니다.');
       }
-      const responseData = (await response.json()) as roomReservationResponseType;
-      alert(`숙소가 성공적으로 예약되었습니다! ID: ${responseData.reservationId}`);
+      const responseData =
+        (await response.json()) as roomReservationResponseType;
+      alert(
+        `숙소가 성공적으로 예약되었습니다! ID: ${responseData.reservationId}`,
+      );
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : '오류가 발생했습니다.';
@@ -77,7 +85,7 @@ const Reservation = ({ data }: InfoProps) => {
             <div className="w-full">
               <button
                 onClick={() => {
-                  openModal('calendar');
+                  openModal('roomCalendar');
                 }}
                 className="flex flex-col items-start mt-1 w-full border border-red-700 rounded-md py-2 px-3 text-gray-700 bg-white cursor-pointer"
               >
@@ -92,7 +100,7 @@ const Reservation = ({ data }: InfoProps) => {
             <div className="w-full">
               <button
                 onClick={() => {
-                  openModal('calendar');
+                  openModal('roomCalendar');
                 }}
                 className="flex flex-col items-start mt-1 w-full border border-red-700 rounded-md py-2 px-3 text-gray-700 bg-white cursor-pointer"
               >
@@ -110,7 +118,7 @@ const Reservation = ({ data }: InfoProps) => {
           <div className="my-4 w-full">
             <button
               onClick={() => {
-                openModal('guests');
+                openModal('roomGuests');
               }}
               className="flex flex-col items-start mt-1 w-full border border-gray-300 rounded-md py-2 px-3 bg-white cursor-pointer text-gray-700"
             >
@@ -165,18 +173,21 @@ const Reservation = ({ data }: InfoProps) => {
         </button>
       </div>
       <BaseModal
-        isOpen={currentModal === 'calendar'}
+        isOpen={currentModal === 'roomCalendar'}
         onClose={closeModal}
         title="날짜 선택"
       >
-        <CalendarModal onClose={closeModal} />
+        <RoomCalendarModal id={data.roomId} onClose={closeModal} />
       </BaseModal>
       <BaseModal
-        isOpen={currentModal === 'guests'}
+        isOpen={currentModal === 'roomGuests'}
         onClose={closeModal}
         title="인원 선택"
       >
-        <GuestsModal onClose={closeModal} />
+        <RoomGuestsModal
+          maxOccupancy={data.maxOccupancy}
+          onClose={closeModal}
+        />
       </BaseModal>
     </>
   );

--- a/src/components/roomdetail/Reservation.tsx
+++ b/src/components/roomdetail/Reservation.tsx
@@ -1,12 +1,13 @@
 import FlagIcon from '@mui/icons-material/Flag';
 import { useState } from 'react';
 
+import clock from '@/assets/icons/reservation/clock.svg';
 import BaseModal from '@/components/common/Modal/BaseModal';
 import { useSearch } from '@/components/home/context/SearchContext';
-import RoomCalendarModal from './roomCalendarModal';
 import RoomGuestsModal from '@/components/roomdetail/RoomGuestsModal';
-import clock from '@/assets/icons/reservation/clock.svg';
 import type { roomType } from '@/types/roomType';
+
+import RoomCalendarModal from './roomCalendarModal';
 
 interface InfoProps {
   data: roomType;

--- a/src/components/roomdetail/ReviewModal.tsx
+++ b/src/components/roomdetail/ReviewModal.tsx
@@ -4,7 +4,7 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { useEffect, useState } from 'react';
 
 import { CheckinIcon } from '@/components/common/constants/icons';
-import accuracy from '@/assets/icons/reviews/clean.svg';
+import accuracy from '@/assets/icons/reviews/accuracy.svg';
 import clean from '@/assets/icons/reviews/clean.svg';
 import type { ReviewsResponse } from '@/types/reviewType';
 import type { roomType } from '@/types/roomType';
@@ -161,7 +161,9 @@ const ReviewModal = ({ onClose, data }: ReviewProps) => {
             <div className="flex justify-between items-start">
               <div className="text-xl ml-8 w-fit h-fit">
                 후기{' '}
-                <span className="font-bold w-fit h-fit">{reviewData?.content.length}</span>
+                <span className="font-bold w-fit h-fit">
+                  {reviewData?.content.length}
+                </span>
                 개
               </div>
               <button
@@ -208,7 +210,9 @@ const ReviewModal = ({ onClose, data }: ReviewProps) => {
                   )}
                   <div className="ml-3">
                     <h5 className="font-medium">{review.nickname}</h5>
-                    <p className="text-xs text-gray-500">숙박 일시&nbsp;{review.startDate}~{review.endDate}</p>
+                    <p className="text-xs text-gray-500">
+                      숙박 일시&nbsp;{review.startDate}~{review.endDate}
+                    </p>
                   </div>
                 </div>
                 <p className="mt-2 text-sm">{review.content}</p>
@@ -217,14 +221,17 @@ const ReviewModal = ({ onClose, data }: ReviewProps) => {
           </div>
         </div>
       </div>
-      {error !== null &&
-        <div className="fixed inset-0 bg-black bg-opacity-50">에러: {error}</div>
-      }
-      {isLoading &&
-        <div className="fixed inset-0 bg-black bg-opacity-50">서버에서 데이터를 가져오는 중...</div>
-      }
+      {error !== null && (
+        <div className="fixed inset-0 bg-black bg-opacity-50">
+          에러: {error}
+        </div>
+      )}
+      {isLoading && (
+        <div className="fixed inset-0 bg-black bg-opacity-50">
+          서버에서 데이터를 가져오는 중...
+        </div>
+      )}
     </div>
-
   );
 };
 

--- a/src/components/roomdetail/ReviewModal.tsx
+++ b/src/components/roomdetail/ReviewModal.tsx
@@ -1,11 +1,11 @@
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import CloseIcon from '@mui/icons-material/Close';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
-import { CheckinIcon } from '@/components/common/constants/icons';
 import accuracy from '@/assets/icons/reviews/accuracy.svg';
 import clean from '@/assets/icons/reviews/clean.svg';
+import { CheckinIcon } from '@/components/common/constants/icons';
 import type { ReviewsResponse } from '@/types/reviewType';
 import type { roomType } from '@/types/roomType';
 
@@ -27,14 +27,10 @@ const ReviewModal = ({ onClose, data }: ReviewProps) => {
     setIsModalOpen(false); // 모달 닫기
   };
 
-  const fetchReviews = async () => {
+  const fetchReviews = useCallback(async () => {
     try {
       setIsLoading(true);
       setError(null);
-
-      if (data.roomId === undefined) {
-        throw new Error('존재하지 않는 숙소입니다.');
-      }
 
       const page = 0;
       const size = 6;
@@ -70,11 +66,11 @@ const ReviewModal = ({ onClose, data }: ReviewProps) => {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [data.roomId, selectedOption]);
 
   useEffect(() => {
     void fetchReviews();
-  }, [data.roomId, selectedOption]);
+  }, [fetchReviews]);
 
   return (
     <div className="fixed inset-0 bg-gray-900 bg-opacity-50 flex justify-center items-center z-50">
@@ -197,17 +193,11 @@ const ReviewModal = ({ onClose, data }: ReviewProps) => {
                 className="rounded-md mx-2 p-5 cursor-pointer hover:bg-gray-100"
               >
                 <div className="flex items-center">
-                  {review.profileImage !== undefined ? (
-                    <div className="w-8 h-8 rounded-full bg-gray-300 text-center leading-8 text-sm">
-                      {review.nickname && review.nickname.charAt(0)}
-                    </div>
-                  ) : (
-                    review.profileImage && (
-                      <div className="w-8 h-8 rounded-full bg-gray-300 text-center leading-8 text-sm">
-                        {review.profileImage}
-                      </div>
-                    )
-                  )}
+                  <div className="w-8 h-8 rounded-full bg-gray-300 text-center leading-8 text-sm">
+                    {review.profileImage !== ''
+                      ? review.nickname
+                      : review.nickname.charAt(0)}
+                  </div>
                   <div className="ml-3">
                     <h5 className="font-medium">{review.nickname}</h5>
                     <p className="text-xs text-gray-500">

--- a/src/components/roomdetail/ReviewModal.tsx
+++ b/src/components/roomdetail/ReviewModal.tsx
@@ -4,8 +4,8 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { useEffect, useState } from 'react';
 
 import { CheckinIcon } from '@/components/common/constants/icons';
-import accuracy from '@/components/roomdetail/accuracy.svg';
-import clean from '@/components/roomdetail/clean.svg';
+import accuracy from '@/assets/icons/reviews/clean.svg';
+import clean from '@/assets/icons/reviews/clean.svg';
 import type { reviewType } from '@/types/reviewType';
 
 const ReviewModal = ({ onClose }: { onClose: () => void }) => {

--- a/src/components/roomdetail/RoomGuestsModal.tsx
+++ b/src/components/roomdetail/RoomGuestsModal.tsx
@@ -1,7 +1,7 @@
+import ErrorIcon from '@mui/icons-material/Error';
 import { useState } from 'react';
 
 import { useSearch } from '@/components/home/context/SearchContext';
-import ErrorIcon from '@mui/icons-material/Error';
 
 type GuestsModalProps = {
   onClose: () => void;

--- a/src/components/roomdetail/RoomGuestsModal.tsx
+++ b/src/components/roomdetail/RoomGuestsModal.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+
+import { useSearch } from '@/components/home/context/SearchContext';
+import ErrorIcon from '@mui/icons-material/Error';
+
+type GuestsModalProps = {
+  onClose: () => void;
+  maxOccupancy: number;
+};
+
+const GuestsModal = ({ onClose, maxOccupancy }: GuestsModalProps) => {
+  const { setGuests } = useSearch();
+  const [guestCount, setGuestCount] = useState(0);
+
+  const handleIncrement = () => {
+    setGuestCount((prev) => prev + 1);
+  };
+
+  const handleDecrement = () => {
+    if (guestCount > 0) {
+      setGuestCount((prev) => prev - 1);
+    }
+  };
+
+  const handleSave = () => {
+    setGuests(guestCount);
+    onClose();
+  };
+
+  return (
+    <div className="p-6">
+      <div className="flex items-center justify-between py-4">
+        <div>
+          <h3 className="text-base font-medium">게스트</h3>
+          <p className="text-sm text-gray-500">숙박 인원을 선택해주세요</p>
+        </div>
+        <div className="flex items-center gap-4">
+          <button
+            onClick={handleDecrement}
+            disabled={guestCount === 0}
+            className={`w-8 h-8 rounded-full border flex items-center justify-center
+              ${guestCount === 0 ? 'border-gray-200 text-gray-200' : 'border-gray-400 text-gray-400 hover:border-gray-700 hover:text-gray-700'}`}
+          >
+            -
+          </button>
+          <span className="w-6 text-center">{guestCount}</span>
+          <button
+            onClick={handleIncrement}
+            className="w-8 h-8 rounded-full border border-gray-400 text-gray-400 hover:border-gray-700 hover:text-gray-700 flex items-center justify-center"
+          >
+            +
+          </button>
+        </div>
+      </div>
+
+      <div className="flex items-center mt-6 pt-4 border-t gap-8">
+        <button onClick={onClose} className="text-base underline font-medium">
+          취소
+        </button>
+        <button
+          onClick={handleSave}
+          className="px-6 py-3 bg-black text-white rounded-lg font-medium"
+        >
+          저장하기
+        </button>
+        {maxOccupancy < guestCount && (
+          <div className="flex items-center gap-2">
+            <ErrorIcon className="text-red-700 text-sm" />
+            <div className="text-sm text-red-700">
+              게스트 인원이 최대 인원을 초과했습니다
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default GuestsModal;

--- a/src/components/roomdetail/roomCalendarModal.tsx
+++ b/src/components/roomdetail/roomCalendarModal.tsx
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import { useEffect, useState } from 'react';
+import { useCallback } from 'react';
 
 import { useSearch } from '@/components/home/context/SearchContext';
 
@@ -13,7 +14,7 @@ type CalendarModalProps = {
   id: number;
 };
 
-const roomCalendarModal = ({ onClose, id }: CalendarModalProps) => {
+const RoomCalendarModal = ({ onClose, id }: CalendarModalProps) => {
   const { checkIn, checkOut, setCheckIn, setCheckOut } = useSearch();
   const [currentMonth, setCurrentMonth] = useState(dayjs());
   const [selecting, setSelecting] = useState<'checkIn' | 'checkOut'>('checkIn');
@@ -30,14 +31,10 @@ const roomCalendarModal = ({ onClose, id }: CalendarModalProps) => {
     setCurrentMonth(currentMonth.subtract(1, 'month'));
   };
 
-  const fetchAvailableDates = async () => {
+  const fetchAvailableDates = useCallback(async () => {
     try {
       setIsLoading(true);
       setError(null);
-
-      if (id === undefined) {
-        throw new Error('존재하지 않는 숙소입니다.');
-      }
 
       const url = `/api/v1/reservations/availability/${id}?year=${currentYear}&month=${currentMonth.month() + 1}`;
 
@@ -62,11 +59,11 @@ const roomCalendarModal = ({ onClose, id }: CalendarModalProps) => {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [id, currentYear, currentMonth]);
 
   useEffect(() => {
     void fetchAvailableDates();
-  }, []);
+  }, [fetchAvailableDates]);
 
   // 날짜가 선택 가능한지 확인
   const isDateSelectable = (date: dayjs.Dayjs) => {
@@ -166,7 +163,7 @@ const roomCalendarModal = ({ onClose, id }: CalendarModalProps) => {
           숙소 예약 가능 날짜 로딩중...
         </div>
       )}
-      {error && (
+      {error !== null && (
         <div className="text-sm text-red-700 bg-red-100 rounded-md p-2">
           에러: 숙소 예약 가능 날짜를 불러올 수 없습니다
         </div>
@@ -242,4 +239,4 @@ const roomCalendarModal = ({ onClose, id }: CalendarModalProps) => {
   );
 };
 
-export default roomCalendarModal;
+export default RoomCalendarModal;

--- a/src/components/roomdetail/roomCalendarModal.tsx
+++ b/src/components/roomdetail/roomCalendarModal.tsx
@@ -1,0 +1,245 @@
+import dayjs from 'dayjs';
+import { useEffect, useState } from 'react';
+
+import { useSearch } from '@/components/home/context/SearchContext';
+
+type AvailabilityResponse = {
+  availableDates: string[];
+  unavailableDates: string[];
+}; // 간단하므로 따로 type 파일 안만듦
+
+type CalendarModalProps = {
+  onClose: () => void;
+  id: number;
+};
+
+const roomCalendarModal = ({ onClose, id }: CalendarModalProps) => {
+  const { checkIn, checkOut, setCheckIn, setCheckOut } = useSearch();
+  const [currentMonth, setCurrentMonth] = useState(dayjs());
+  const [selecting, setSelecting] = useState<'checkIn' | 'checkOut'>('checkIn');
+  const [availableDates, setAvailableDates] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const currentYear: number = currentMonth.year();
+
+  // 다음/이전 달로 이동
+  const goToNextMonth = () => {
+    setCurrentMonth(currentMonth.add(1, 'month'));
+  };
+  const goToPrevMonth = () => {
+    setCurrentMonth(currentMonth.subtract(1, 'month'));
+  };
+
+  const fetchAvailableDates = async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      if (id === undefined) {
+        throw new Error('존재하지 않는 숙소입니다.');
+      }
+
+      const url = `/api/v1/reservations/availability/${id}?year=${currentYear}&month=${currentMonth.month() + 1}`;
+
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error('숙소 예약 가능 날짜 로딩에 실패했습니다.');
+      }
+
+      const responseData = (await response.json()) as AvailabilityResponse;
+      console.debug(responseData);
+      setAvailableDates(responseData.availableDates);
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : '오류가 발생했습니다.';
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void fetchAvailableDates();
+  }, []);
+
+  // 날짜가 선택 가능한지 확인
+  const isDateSelectable = (date: dayjs.Dayjs) => {
+    const today = dayjs().startOf('day');
+    const isBeforeToday = date.isBefore(today);
+    const isAvailable = availableDates.includes(date.format('YYYY-MM-DD'));
+
+    // 체크아웃 선택 중이고 체크인 날짜가 있는 경우
+    if (selecting === 'checkOut' && checkIn !== null) {
+      const checkInDate = dayjs(checkIn); // Date를 dayjs 객체로 변환
+      const isBeforeCheckIn = date.isBefore(checkInDate.add(1, 'day'), 'day');
+      return !isBeforeToday && !isBeforeCheckIn && isAvailable;
+    } //리팩토링: 체크인, 체크아웃 범위에 예약 불가한 날짜가 있는 경우도 제외해야 함
+
+    return !isBeforeToday && isAvailable;
+  };
+
+  // 날짜 선택 핸들러
+  const handleDateSelect = (date: dayjs.Dayjs) => {
+    if (!isDateSelectable(date)) return;
+
+    if (selecting === 'checkIn') {
+      setCheckIn(date.toDate());
+      setSelecting('checkOut');
+    } else {
+      setCheckOut(date.toDate());
+      onClose();
+    }
+  };
+
+  // 캘린더 생성 함수
+  const renderCalendar = (monthDate: dayjs.Dayjs) => {
+    const daysInMonth = monthDate.daysInMonth();
+    const firstDayOfMonth = monthDate.startOf('month').day();
+    const weeks = [];
+    let days = [];
+
+    // 첫 주의 빈 날짜 채우기
+    for (let i = 0; i < firstDayOfMonth; i++) {
+      days.push(<td key={`empty-${i}`} className="p-0"></td>);
+    }
+
+    // 날짜 채우기
+    for (let day = 1; day <= daysInMonth; day++) {
+      const date = monthDate.date(day);
+      const isSelectable = isDateSelectable(date);
+      const isSelected = (currentDate: dayjs.Dayjs) => {
+        const checkInDate = checkIn !== null ? dayjs(checkIn) : null;
+        const checkOutDate = checkOut !== null ? dayjs(checkOut) : null;
+
+        return (
+          (checkInDate !== null && checkInDate.isSame(currentDate, 'day')) ||
+          (checkOutDate !== null && checkOutDate.isSame(currentDate, 'day'))
+        );
+      };
+      const isInRange =
+        checkIn !== null &&
+        checkOut !== null &&
+        date.isAfter(checkIn) &&
+        date.isBefore(checkOut);
+
+      days.push(
+        <td key={day} className="p-0">
+          <button
+            onClick={() => {
+              handleDateSelect(date);
+            }}
+            disabled={!isSelectable}
+            className={`w-12 h-12 rounded-full mx-auto flex items-center justify-center
+              ${!isSelectable ? 'text-gray-300 cursor-not-allowed' : 'hover:bg-gray-100'}
+              ${isSelected(date) ? 'bg-black text-white hover:bg-black' : ''}
+              ${isInRange ? 'bg-gray-100' : ''}
+            `}
+          >
+            {day}
+          </button>
+        </td>,
+      );
+
+      if (days.length === 7) {
+        weeks.push(<tr key={day}>{days}</tr>);
+        days = [];
+      }
+    }
+
+    if (days.length > 0) {
+      weeks.push(<tr key="last">{days}</tr>);
+    }
+
+    return weeks;
+  };
+
+  return (
+    <div className="flex flex-col items-center">
+      {isLoading && (
+        <div className="fixed inset-0 bg-gray-900 bg-opacity-50 flex justify-center items-center text-lg text-blacks">
+          숙소 예약 가능 날짜 로딩중...
+        </div>
+      )}
+      {error && (
+        <div className="text-sm text-red-700 bg-red-100 rounded-md p-2">
+          에러: 숙소 예약 가능 날짜를 불러올 수 없습니다
+        </div>
+      )}
+      <div className="flex justify-between items-center mb-8 p-6">
+        <button
+          onClick={goToPrevMonth}
+          className="p-2 hover:bg-gray-100 rounded-full"
+        >
+          ←
+        </button>
+        <div className="grid grid-cols-2 gap-8">
+          {/* 현재 달 */}
+          <div className="min-w-[280px]">
+            <h3 className="text-center font-medium mb-4">
+              {currentMonth.format('YYYY년 M월')}
+            </h3>
+            <table className="w-full border-separate border-spacing-0">
+              <thead>
+                <tr>
+                  {['일', '월', '화', '수', '목', '금', '토'].map((day) => (
+                    <th
+                      key={day}
+                      className="p-1 text-center text-sm font-medium"
+                    >
+                      {day}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="text-sm">{renderCalendar(currentMonth)}</tbody>
+            </table>
+          </div>
+
+          {/* 다음 달 */}
+          <div className="min-w-[280px]">
+            <h3 className="text-center font-medium mb-4">
+              {currentMonth.add(1, 'month').format('YYYY년 M월')}
+            </h3>
+            <table className="w-full border-separate border-spacing-0">
+              <thead>
+                <tr>
+                  {['일', '월', '화', '수', '목', '금', '토'].map((day) => (
+                    <th
+                      key={day}
+                      className="p-1 text-center text-sm font-medium"
+                    >
+                      {day}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="text-sm">
+                {renderCalendar(currentMonth.add(1, 'month'))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <button
+          onClick={goToNextMonth}
+          className="p-2 hover:bg-gray-100 rounded-full"
+        >
+          →
+        </button>
+      </div>
+
+      <div className="text-center text-gray-500">
+        {selecting === 'checkIn'
+          ? '체크인 날짜를 선택해주세요.'
+          : '체크아웃 날짜를 선택해주세요.'}
+      </div>
+    </div>
+  );
+};
+
+export default roomCalendarModal;

--- a/src/routes/roomDetail.tsx
+++ b/src/routes/roomDetail.tsx
@@ -2,7 +2,7 @@ import { PhotoSizeSelectActual as PhotoSizeSelectActualIcon } from '@mui/icons-m
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-import gallery from '@/components/common/gallery.svg';
+import gallery from '@/assets/icons/roomdetail/gallery.svg'
 import Topbar from '@/components/home/Topbar';
 import Info from '@/components/roomdetail/Info';
 import PhotoModal from '@/components/roomdetail/PhotoModal';
@@ -23,10 +23,6 @@ export const Roomdetail = () => {
         setIsLoading(true);
         setError(null);
 
-        const token = localStorage.getItem('token');
-        if (token === null) {
-          throw new Error('로그인이 필요합니다.');
-        }
         if (id === undefined) {
           throw new Error('존재하지 않는 숙소입니다.');
         }
@@ -35,7 +31,6 @@ export const Roomdetail = () => {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
           },
         });
 

--- a/src/routes/roomDetail.tsx
+++ b/src/routes/roomDetail.tsx
@@ -2,7 +2,7 @@ import { PhotoSizeSelectActual as PhotoSizeSelectActualIcon } from '@mui/icons-m
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-import gallery from '@/assets/icons/roomdetail/gallery.svg'
+import gallery from '@/assets/icons/roomdetail/gallery.svg';
 import Topbar from '@/components/home/Topbar';
 import Info from '@/components/roomdetail/Info';
 import PhotoModal from '@/components/roomdetail/PhotoModal';

--- a/src/routes/roomDetail.tsx
+++ b/src/routes/roomDetail.tsx
@@ -48,14 +48,14 @@ export const Roomdetail = () => {
       }
     };
     void handleDetail();
-  }, [id]);
+  }, []);
 
   return (
     <div className="flex flex-col justify-start items-center w-full">
       <Topbar />
       <div className="flex flex-col w-full px-[55px]">
         <div className="flex w-full items-end justify-between py-4">
-          <div className="text-2xl font-normal">{roomData?.name}</div>
+          <div className="text-2xl font-normal">{roomData?.roomName}</div>
           <Shareheart />
         </div>
         <div className="grid grid-cols-4 grid-rows-2 gap-2 w-full h-[330px]">

--- a/src/routes/roomDetail.tsx
+++ b/src/routes/roomDetail.tsx
@@ -48,7 +48,7 @@ export const Roomdetail = () => {
       }
     };
     void handleDetail();
-  }, []);
+  }, [id]);
 
   return (
     <div className="flex flex-col justify-start items-center w-full">

--- a/src/types/reviewType.ts
+++ b/src/types/reviewType.ts
@@ -1,7 +1,38 @@
-export type reviewType = {
-  name: string;
-  joined: string;
-  date: string;
+interface Review {
+  userId: number;
+  nickname: string;
+  profileImage: string;
   content: string;
-  hostReply: string;
-};
+  rating: number;
+  startDate: string; // ISO 8601 날짜 형식 (예: "2025-01-01")
+  endDate: string;   // ISO 8601 날짜 형식 (예: "2025-01-02")
+}
+
+interface Sort {
+  empty: boolean;
+  sorted: boolean;
+  unsorted: boolean;
+}
+
+interface Pageable {
+  pageNumber: number;
+  pageSize: number;
+  sort: Sort;
+  offset: number;
+  unpaged: boolean;
+  paged: boolean;
+}
+
+export interface ReviewsResponse {
+  content: Review[];        // 리뷰 항목
+  pageable: Pageable;       // 페이징 정보
+  totalElements: number;    // 전체 리뷰 수
+  totalPages: number;       // 전체 페이지 수
+  last: boolean;            // 마지막 페이지 여부
+  size: number;             // 한 페이지의 리뷰 수
+  number: number;           // 현재 페이지 번호
+  sort: Sort;               // 정렬 정보
+  numberOfElements: number; // 현재 페이지의 리뷰 개수
+  first: boolean;           // 첫 번째 페이지 여부
+  empty: boolean;           // 페이지 내용이 비어 있는지 여부
+}

--- a/src/types/reviewType.ts
+++ b/src/types/reviewType.ts
@@ -5,7 +5,7 @@ interface Review {
   content: string;
   rating: number;
   startDate: string; // ISO 8601 날짜 형식 (예: "2025-01-01")
-  endDate: string;   // ISO 8601 날짜 형식 (예: "2025-01-02")
+  endDate: string; // ISO 8601 날짜 형식 (예: "2025-01-02")
 }
 
 interface Sort {
@@ -24,15 +24,15 @@ interface Pageable {
 }
 
 export interface ReviewsResponse {
-  content: Review[];        // 리뷰 항목
-  pageable: Pageable;       // 페이징 정보
-  totalElements: number;    // 전체 리뷰 수
-  totalPages: number;       // 전체 페이지 수
-  last: boolean;            // 마지막 페이지 여부
-  size: number;             // 한 페이지의 리뷰 수
-  number: number;           // 현재 페이지 번호
-  sort: Sort;               // 정렬 정보
+  content: Review[]; // 리뷰 항목
+  pageable: Pageable; // 페이징 정보
+  totalElements: number; // 전체 리뷰 수
+  totalPages: number; // 전체 페이지 수
+  last: boolean; // 마지막 페이지 여부
+  size: number; // 한 페이지의 리뷰 수
+  number: number; // 현재 페이지 번호
+  sort: Sort; // 정렬 정보
   numberOfElements: number; // 현재 페이지의 리뷰 개수
-  first: boolean;           // 첫 번째 페이지 여부
-  empty: boolean;           // 페이지 내용이 비어 있는지 여부
+  first: boolean; // 첫 번째 페이지 여부
+  empty: boolean; // 페이지 내용이 비어 있는지 여부
 }

--- a/src/types/roomReservationType.ts
+++ b/src/types/roomReservationType.ts
@@ -1,6 +1,0 @@
-export type roomReservationType = {
-  roomId: string;
-  startDate: string;
-  endDate: string;
-  numberOfGuests: string;
-};

--- a/src/types/roomType.ts
+++ b/src/types/roomType.ts
@@ -23,16 +23,16 @@ type Price = {
 };
 
 export type roomType = {
-  id: number;
+  roomId: number;
   hostId: number;
-  name: string;
+  roomName: string;
   description: string;
-  type: string; // 예시로 더 많은 타입을 추가할 수 있습니다.
+  roomType: string; // 예시로 더 많은 타입을 추가할 수 있습니다.
   address: Address;
   roomDetails: RoomDetails;
   price: Price;
   maxOccupancy: number;
-  rating: number;
+  averageRating: number;
   reviewCount: number;
   isSuperhost: boolean;
   createdAt: string; // ISO 8601 날짜 형식

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,10 +33,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.25.9":
-  version: 7.26.3
-  resolution: "@babel/compat-data@npm:7.26.3"
-  checksum: 10c0/d63e71845c34dfad8d7ff8c15b562e620dbf60e68e3abfa35681d24d612594e8e5ec9790d831a287ecd79ce00f48e7ffddc85c5ce94af7242d45917b9c1a5f90
+"@babel/compat-data@npm:^7.26.5":
+  version: 7.26.5
+  resolution: "@babel/compat-data@npm:7.26.5"
+  checksum: 10c0/9d2b41f0948c3dfc5de44d9f789d2208c2ea1fd7eb896dfbb297fe955e696728d6f363c600cd211e7f58ccbc2d834fe516bb1e4cf883bbabed8a32b038afc1a0
   languageName: node
   linkType: hard
 
@@ -63,29 +63,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.26.0, @babel/generator@npm:^7.26.3":
-  version: 7.26.3
-  resolution: "@babel/generator@npm:7.26.3"
+"@babel/generator@npm:^7.26.0, @babel/generator@npm:^7.26.5":
+  version: 7.26.5
+  resolution: "@babel/generator@npm:7.26.5"
   dependencies:
-    "@babel/parser": "npm:^7.26.3"
-    "@babel/types": "npm:^7.26.3"
+    "@babel/parser": "npm:^7.26.5"
+    "@babel/types": "npm:^7.26.5"
     "@jridgewell/gen-mapping": "npm:^0.3.5"
     "@jridgewell/trace-mapping": "npm:^0.3.25"
     jsesc: "npm:^3.0.2"
-  checksum: 10c0/54f260558e3e4ec8942da3cde607c35349bb983c3a7c5121243f96893fba3e8cd62e1f1773b2051f936f8c8a10987b758d5c7d76dbf2784e95bb63ab4843fa00
+  checksum: 10c0/3be79e0aa03f38858a465d12ee2e468320b9122dc44fc85984713e32f16f4d77ce34a16a1a9505972782590e0b8d847b6f373621f9c6fafa1906d90f31416cb0
   languageName: node
   linkType: hard
 
 "@babel/helper-compilation-targets@npm:^7.25.9":
-  version: 7.25.9
-  resolution: "@babel/helper-compilation-targets@npm:7.25.9"
+  version: 7.26.5
+  resolution: "@babel/helper-compilation-targets@npm:7.26.5"
   dependencies:
-    "@babel/compat-data": "npm:^7.25.9"
+    "@babel/compat-data": "npm:^7.26.5"
     "@babel/helper-validator-option": "npm:^7.25.9"
     browserslist: "npm:^4.24.0"
     lru-cache: "npm:^5.1.1"
     semver: "npm:^6.3.1"
-  checksum: 10c0/a6b26a1e4222e69ef8e62ee19374308f060b007828bc11c65025ecc9e814aba21ff2175d6d3f8bf53c863edd728ee8f94ba7870f8f90a37d39552ad9933a8aaa
+  checksum: 10c0/9da5c77e5722f1a2fcb3e893049a01d414124522bbf51323bb1a0c9dcd326f15279836450fc36f83c9e8a846f3c40e88be032ed939c5a9840922bed6073edfb4
   languageName: node
   linkType: hard
 
@@ -113,9 +113,9 @@ __metadata:
   linkType: hard
 
 "@babel/helper-plugin-utils@npm:^7.25.9":
-  version: 7.25.9
-  resolution: "@babel/helper-plugin-utils@npm:7.25.9"
-  checksum: 10c0/483066a1ba36ff16c0116cd24f93de05de746a603a777cd695ac7a1b034928a65a4ecb35f255761ca56626435d7abdb73219eba196f9aa83b6c3c3169325599d
+  version: 7.26.5
+  resolution: "@babel/helper-plugin-utils@npm:7.26.5"
+  checksum: 10c0/cdaba71d4b891aa6a8dfbe5bac2f94effb13e5fa4c2c487667fdbaa04eae059b78b28d85a885071f45f7205aeb56d16759e1bed9c118b94b16e4720ef1ab0f65
   languageName: node
   linkType: hard
 
@@ -150,14 +150,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.25.9, @babel/parser@npm:^7.26.0, @babel/parser@npm:^7.26.3":
-  version: 7.26.3
-  resolution: "@babel/parser@npm:7.26.3"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.25.9, @babel/parser@npm:^7.26.0, @babel/parser@npm:^7.26.5":
+  version: 7.26.5
+  resolution: "@babel/parser@npm:7.26.5"
   dependencies:
-    "@babel/types": "npm:^7.26.3"
+    "@babel/types": "npm:^7.26.5"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 10c0/48f736374e61cfd10ddbf7b80678514ae1f16d0e88bc793d2b505d73d9b987ea786fc8c2f7ee8f8b8c467df062030eb07fd0eb2168f0f541ca1f542775852cad
+  checksum: 10c0/2e77dd99ee028ee3c10fa03517ae1169f2432751adf71315e4dc0d90b61639d51760d622f418f6ac665ae4ea65f8485232a112ea0e76f18e5900225d3d19a61e
   languageName: node
   linkType: hard
 
@@ -204,27 +204,27 @@ __metadata:
   linkType: hard
 
 "@babel/traverse@npm:^7.25.9":
-  version: 7.26.4
-  resolution: "@babel/traverse@npm:7.26.4"
+  version: 7.26.5
+  resolution: "@babel/traverse@npm:7.26.5"
   dependencies:
     "@babel/code-frame": "npm:^7.26.2"
-    "@babel/generator": "npm:^7.26.3"
-    "@babel/parser": "npm:^7.26.3"
+    "@babel/generator": "npm:^7.26.5"
+    "@babel/parser": "npm:^7.26.5"
     "@babel/template": "npm:^7.25.9"
-    "@babel/types": "npm:^7.26.3"
+    "@babel/types": "npm:^7.26.5"
     debug: "npm:^4.3.1"
     globals: "npm:^11.1.0"
-  checksum: 10c0/cf25d0eda9505daa0f0832ad786b9e28c9d967e823aaf7fbe425250ab198c656085495aa6bed678b27929e095c84eea9fd778b851a31803da94c9bc4bf4eaef7
+  checksum: 10c0/0779059ecf63e31446564cf31adf170e701e8017ef02c819c57924a9a83d6b2ce41dbff3ef295589da9410497a3e575655bb8084ca470e0ab1bc193128afa9fe
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.25.9, @babel/types@npm:^7.26.0, @babel/types@npm:^7.26.3":
-  version: 7.26.3
-  resolution: "@babel/types@npm:7.26.3"
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.25.9, @babel/types@npm:^7.26.0, @babel/types@npm:^7.26.5":
+  version: 7.26.5
+  resolution: "@babel/types@npm:7.26.5"
   dependencies:
     "@babel/helper-string-parser": "npm:^7.25.9"
     "@babel/helper-validator-identifier": "npm:^7.25.9"
-  checksum: 10c0/966c5242c5e55c8704bf7a7418e7be2703a0afa4d19a8480999d5a4ef13d095dd60686615fe5983cb7593b4b06ba3a7de8d6ca501c1d78bdd233a10d90be787b
+  checksum: 10c0/0278053b69d7c2b8573aa36dc5242cad95f0d965e1c0ed21ccacac6330092e59ba5949753448f6d6eccf6ad59baaef270295cc05218352e060ea8c68388638c4
   languageName: node
   linkType: hard
 
@@ -576,6 +576,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/core@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@eslint/core@npm:0.10.0"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.15"
+  checksum: 10c0/074018075079b3ed1f14fab9d116f11a8824cdfae3e822badf7ad546962fafe717a31e61459bad8cc59cf7070dc413ea9064ddb75c114f05b05921029cde0a64
+  languageName: node
+  linkType: hard
+
 "@eslint/core@npm:^0.6.0":
   version: 0.6.0
   resolution: "@eslint/core@npm:0.6.0"
@@ -615,11 +624,12 @@ __metadata:
   linkType: hard
 
 "@eslint/plugin-kit@npm:^0.2.0":
-  version: 0.2.4
-  resolution: "@eslint/plugin-kit@npm:0.2.4"
+  version: 0.2.5
+  resolution: "@eslint/plugin-kit@npm:0.2.5"
   dependencies:
+    "@eslint/core": "npm:^0.10.0"
     levn: "npm:^0.4.1"
-  checksum: 10c0/1bcfc0a30b1df891047c1d8b3707833bded12a057ba01757a2a8591fdc8d8fe0dbb8d51d4b0b61b2af4ca1d363057abd7d2fb4799f1706b105734f4d3fa0dbf1
+  checksum: 10c0/ba9832b8409af618cf61791805fe201dd62f3c82c783adfcec0f5cd391e68b40beaecb47b9a3209e926dbcab65135f410cae405b69a559197795793399f61176
   languageName: node
   linkType: hard
 
@@ -719,38 +729,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/core-downloads-tracker@npm:^6.3.1":
-  version: 6.3.1
-  resolution: "@mui/core-downloads-tracker@npm:6.3.1"
-  checksum: 10c0/a996ad8db6bd8c981c4e2e2d243526c838dd29f0bbe7dc5ab6933be357e41f748781d322b1decf79ae1c9abba24190162559d84deedcb7c8824a68754dddf216
+"@mui/core-downloads-tracker@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "@mui/core-downloads-tracker@npm:6.4.0"
+  checksum: 10c0/48112fb90df2fe58fdbc8ca9c8fac3487dc3aa0fbc31bd1e6b373f43f5bbb23d6fc673686b42cb46723e2d8c66ae914ecb9397c38e7d43a340ec6cbe07e1469d
   languageName: node
   linkType: hard
 
 "@mui/icons-material@npm:^6.3.1":
-  version: 6.3.1
-  resolution: "@mui/icons-material@npm:6.3.1"
+  version: 6.4.0
+  resolution: "@mui/icons-material@npm:6.4.0"
   dependencies:
     "@babel/runtime": "npm:^7.26.0"
   peerDependencies:
-    "@mui/material": ^6.3.1
+    "@mui/material": ^6.4.0
     "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10c0/edaf71b7368c14cfbfed6f475ef96187871a010e972b9e7608d23cadae5ce52a3a6888b32453721dc1d86e2e7ad9c61aadde83ba5cd94363782bf83803d1ab36
+  checksum: 10c0/5e05dbb67e0f7e0c046d5665bebf41df487b31ce617987ac0e8da9c539221bad7e523bf77f0f0153b35aadb56f02146aded567e8032ba608696f70b708d505c0
   languageName: node
   linkType: hard
 
 "@mui/material@npm:^6.3.1":
-  version: 6.3.1
-  resolution: "@mui/material@npm:6.3.1"
+  version: 6.4.0
+  resolution: "@mui/material@npm:6.4.0"
   dependencies:
     "@babel/runtime": "npm:^7.26.0"
-    "@mui/core-downloads-tracker": "npm:^6.3.1"
-    "@mui/system": "npm:^6.3.1"
+    "@mui/core-downloads-tracker": "npm:^6.4.0"
+    "@mui/system": "npm:^6.4.0"
     "@mui/types": "npm:^7.2.21"
-    "@mui/utils": "npm:^6.3.1"
+    "@mui/utils": "npm:^6.4.0"
     "@popperjs/core": "npm:^2.11.8"
     "@types/react-transition-group": "npm:^4.4.12"
     clsx: "npm:^2.1.1"
@@ -761,7 +771,7 @@ __metadata:
   peerDependencies:
     "@emotion/react": ^11.5.0
     "@emotion/styled": ^11.3.0
-    "@mui/material-pigment-css": ^6.3.1
+    "@mui/material-pigment-css": ^6.4.0
     "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -774,16 +784,16 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 10c0/7fb91acd9bc021dde78e70d495a2abd69d0e2df35e526e0730e060c3177bb10cc3058ee27c72b5ec9bc7622d9c2ef99831b89f511f6700bc3717f979e2cb0152
+  checksum: 10c0/5bd9757b578827d841934725a7145ae1d295cbc979fec4fb1a099c439ae0db1a67ace47b2a94f289ac5289d16b0167ebba9a4e98b0499840555b60fb5b549923
   languageName: node
   linkType: hard
 
-"@mui/private-theming@npm:^6.3.1":
-  version: 6.3.1
-  resolution: "@mui/private-theming@npm:6.3.1"
+"@mui/private-theming@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "@mui/private-theming@npm:6.4.0"
   dependencies:
     "@babel/runtime": "npm:^7.26.0"
-    "@mui/utils": "npm:^6.3.1"
+    "@mui/utils": "npm:^6.4.0"
     prop-types: "npm:^15.8.1"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -791,13 +801,13 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10c0/aafaca0d7e5fd4d83c2cade28b7de554c0d848595f8f23f26c8f7daf3fc664053c9c81342d44d24e0a04a4813b58d6f0c1d135ae2775380acda91468a21f9684
+  checksum: 10c0/3e89ff9e6baf85b1bdb0ed55e1ef50dadd95991ed498928e1764c1255fa174c0d134a46beebb1e4faabc22820b404923911c2bf6e9692fd269a77522c356eb6c
   languageName: node
   linkType: hard
 
-"@mui/styled-engine@npm:^6.3.1":
-  version: 6.3.1
-  resolution: "@mui/styled-engine@npm:6.3.1"
+"@mui/styled-engine@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "@mui/styled-engine@npm:6.4.0"
   dependencies:
     "@babel/runtime": "npm:^7.26.0"
     "@emotion/cache": "npm:^11.13.5"
@@ -814,19 +824,19 @@ __metadata:
       optional: true
     "@emotion/styled":
       optional: true
-  checksum: 10c0/81bbf8f2016b1c7debbbaab1a44ebaf8e494e8c9d32d2201b28f8c653a082177f6570fef779bf835bad1a9120af219a64b1d7a9a8a569c9c07045f00affe6b87
+  checksum: 10c0/bff35147ca9ef586679b53786d840e98837f0c1e5bf10a3510d4b2b68c340ae4ab69befe94b69ef25f6846bada5b3c355d25fa3a179d1598499e28c51f28d5d2
   languageName: node
   linkType: hard
 
-"@mui/system@npm:^6.3.1":
-  version: 6.3.1
-  resolution: "@mui/system@npm:6.3.1"
+"@mui/system@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "@mui/system@npm:6.4.0"
   dependencies:
     "@babel/runtime": "npm:^7.26.0"
-    "@mui/private-theming": "npm:^6.3.1"
-    "@mui/styled-engine": "npm:^6.3.1"
+    "@mui/private-theming": "npm:^6.4.0"
+    "@mui/styled-engine": "npm:^6.4.0"
     "@mui/types": "npm:^7.2.21"
-    "@mui/utils": "npm:^6.3.1"
+    "@mui/utils": "npm:^6.4.0"
     clsx: "npm:^2.1.1"
     csstype: "npm:^3.1.3"
     prop-types: "npm:^15.8.1"
@@ -842,7 +852,7 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 10c0/49613b001f7e60c7ed70f3e2ee3ffc4f3a2719509e4f9ec18faf73a354597b8d894d0ee8861bf3a5b5db763efca36bcfb75989505c88e009c1627b114bac88ef
+  checksum: 10c0/5e8d82674693d747b947ce4e5c1a11fff148c5242b2af898d80575e780f0abd3857f234a47b1cec16ca02334ecc7450f0afb5e311ddee9e9cf342e5bf3c7c1fc
   languageName: node
   linkType: hard
 
@@ -858,9 +868,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/utils@npm:^6.3.1":
-  version: 6.3.1
-  resolution: "@mui/utils@npm:6.3.1"
+"@mui/utils@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "@mui/utils@npm:6.4.0"
   dependencies:
     "@babel/runtime": "npm:^7.26.0"
     "@mui/types": "npm:^7.2.21"
@@ -874,7 +884,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10c0/b111bca7ad065b1028714d55a8df90267c47a72ffb2bfad7a1709cef0d5d9036b463855d431b3606967c9351c7ee23f1dee02457b2f3ed02513744f0173eb00c
+  checksum: 10c0/c72ab7685affb577f1b48a5f5be02d11254cddf858cc35d61e0483434249cc064f2d145e9e72be60c344f31ccc7d6e61c59a256413b7e68077e883c0ffc8882e
   languageName: node
   linkType: hard
 
@@ -2071,9 +2081,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.73":
-  version: 1.5.79
-  resolution: "electron-to-chromium@npm:1.5.79"
-  checksum: 10c0/ad781ad55add24b5c61c9d77c3a8efeb781ca0de9d9e4dd55658c70447ac41297d0babfd975d59eeab83de5f863ab1309276d310648f0316231340eb9a18590e
+  version: 1.5.83
+  resolution: "electron-to-chromium@npm:1.5.83"
+  checksum: 10c0/12380962d057c4679add1047cdddb18b909904614272da0527e505a3859eaffde2022dd0688ce7f230582de96405c3d33b667680614475cdafd3f629caa2fee1
   languageName: node
   linkType: hard
 
@@ -2231,11 +2241,11 @@ __metadata:
   linkType: hard
 
 "es-object-atoms@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "es-object-atoms@npm:1.0.0"
+  version: 1.1.1
+  resolution: "es-object-atoms@npm:1.1.1"
   dependencies:
     es-errors: "npm:^1.3.0"
-  checksum: 10c0/1fed3d102eb27ab8d983337bb7c8b159dd2a1e63ff833ec54eea1311c96d5b08223b433060ba240541ca8adba9eee6b0a60cdbf2f80634b784febc9cc8b687b4
+  checksum: 10c0/65364812ca4daf48eb76e2a3b7a89b3f6a2e62a1c420766ce9f692665a29d94fe41fe88b65f24106f449859549711e4b40d9fb8002d862dfd7eb1c512d10be0c
   languageName: node
   linkType: hard
 
@@ -3711,7 +3721,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.7":
+"nanoid@npm:^3.3.7, nanoid@npm:^3.3.8":
   version: 3.3.8
   resolution: "nanoid@npm:3.3.8"
   bin:
@@ -4107,7 +4117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.49, postcss@npm:^8.4.43, postcss@npm:^8.4.47":
+"postcss@npm:8.4.49":
   version: 8.4.49
   resolution: "postcss@npm:8.4.49"
   dependencies:
@@ -4115,6 +4125,17 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/f1b3f17aaf36d136f59ec373459f18129908235e65dbdc3aee5eef8eba0756106f52de5ec4682e29a2eab53eb25170e7e871b3e4b52a8f1de3d344a514306be3
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.43, postcss@npm:^8.4.47":
+  version: 8.5.1
+  resolution: "postcss@npm:8.5.1"
+  dependencies:
+    nanoid: "npm:^3.3.8"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/c4d90c59c98e8a0c102b77d3f4cac190f883b42d63dc60e2f3ed840f16197c0c8e25a4327d2e9a847b45a985612317dc0534178feeebd0a1cf3eb0eecf75cae4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 주요 사항
- 상세화면 GET /api/v1/reservations/availability/{roomId} 캘린더에 예약 가능 날짜 연결했습니다 (SearchBar와 별개로 상세화면에 사용할 모달 생성했습니다)
- 상세화면 게스트 인원 초과 시 경고가 뜨도록 했습니다 (Increment 자체가 안되도록 수정할 예정입니다) (SearchBar와 별개로 상세화면에 사용할 모달 생성했습니다)
- 상세화면 GET /api/v1/reviews/room/{roomId}
 상세화면 리뷰 조회 연결했습니다 (페이지 분류 미완)
- HeartModal 껍데기 구현 완료했습니다

## 🚧 (스프린트 3) 앞으로 작업할 기능
- 상세화면 리뷰 조회 페이지 분류하기 (무한 스크롤?)
- 상세화면 게스트 인원 초과해서 Increment 자체가 안되도록 수정하기
- 이미지 api 연결